### PR TITLE
added keyReleased event to ITool

### DIFF
--- a/EtherGL/src/ch/fhnw/ether/controller/DefaultController.java
+++ b/EtherGL/src/ch/fhnw/ether/controller/DefaultController.java
@@ -284,6 +284,13 @@ public class DefaultController implements IController {
 
 	@Override
 	public void keyReleased(IKeyEvent e) {
+		if (DBG)
+			System.out.println("key released " + e.getView());
+
+		setCurrentView(e.getView());
+
+		// pass on to tool
+		currentTool.keyReleased(e);
 	}
 
 	// pointer listener

--- a/EtherGL/src/ch/fhnw/ether/controller/tool/AbstractTool.java
+++ b/EtherGL/src/ch/fhnw/ether/controller/tool/AbstractTool.java
@@ -69,6 +69,10 @@ public abstract class AbstractTool implements ITool {
 	@Override
 	public void keyPressed(IKeyEvent e) {
 	}
+	
+	@Override
+	public void keyReleased(IKeyEvent e) {
+	}
 
 	// mouse listener
 

--- a/EtherGL/src/ch/fhnw/ether/controller/tool/ITool.java
+++ b/EtherGL/src/ch/fhnw/ether/controller/tool/ITool.java
@@ -56,22 +56,17 @@ public interface ITool {
 	void refresh(IView view);
 
 	// key listener
-
 	void keyPressed(IKeyEvent e);
+	void keyReleased(IKeyEvent e);
 
 	// pointer listener
-
 	void pointerPressed(IPointerEvent e);
-
 	void pointerReleased(IPointerEvent e);
 
 	// pointer motion listener
-
 	void pointerMoved(IPointerEvent e);
-
 	void pointerDragged(IPointerEvent e);
 
 	// pointer scroll listener
-
 	void pointerScrolled(IPointerEvent e);
 }


### PR DESCRIPTION
Please check wether keyReleased in DefaultController is implemented correctly. I don't know what:
```java
setCurrentView(e.getView());
```
exactly is for.

Other suggestion:
Move all the event handler method in to one or multiple parent interfaces. Currently the handle methods are defined at least three times. In UI, IController and ITool.
If java8 is okay we could implement them with default methods so they don't have to be implemented if not needed.

Regards

David