### PR TITLE
Added methods to change and access the title of a window

### DIFF
--- a/EtherGL/src/ch/fhnw/ether/view/IWindow.java
+++ b/EtherGL/src/ch/fhnw/ether/view/IWindow.java
@@ -61,4 +61,16 @@ public interface IWindow {
 	 * Display (i.e. render) this view. Must be run from render thread.
 	 */
 	void display(GLRunnable runnable);
+
+	/**
+	 * Returns the title, which is currently displayed for this window.
+	 * @return
+	 */
+	String getTitle();
+
+	/**
+	 * Changes the title of this window to the given string.
+	 * @param title New window title.
+	 */
+	void setTitle(String title);
 }

--- a/EtherGL/src/ch/fhnw/ether/view/gl/NEWTWindow.java
+++ b/EtherGL/src/ch/fhnw/ether/view/gl/NEWTWindow.java
@@ -186,4 +186,14 @@ final class NEWTWindow implements IWindow {
 	public void display(GLRunnable runnable) {
 		window.invoke(false, runnable);
 	}
+
+	@Override
+	public String getTitle() {
+		return window.getTitle();
+	}
+
+	@Override
+	public void setTitle(String title) {
+		window.setTitle(title);
+	}
 }


### PR DESCRIPTION
Added this method, because it would be great to show the file names as title in editor applications.
(TheJP/CptHook#4)

Moved the methods to IWindow (as suggested in #4).